### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+هذا التطبيق هو نظام لإدارة الملفات مصمم لتلبية احتياجات إدارة الملفات بشكل آمن. يسمح النظام بإدارة الملفات حسب الفروع مع وجود أدوار مختلفة للمشرفين والمستخدمين العاديين. يمكن للمشرفين إدارة الملفات والمستخدمين ومتابعة عمليات الفرع، بينما يمكن للمستخدمين العاديين رفع الملفات ومشاهدتها ضمن قسمهم.
+
+يستخدم التطبيق Laravel مع Breeze لإدارة الخلفية و React مع Inertia.js للواجهة الأمامية، مما يتيح تجربة تفاعلية وسلسة للمستخدمين.
+
+الميزات:
+
+الوصول بناءً على الدور: يميز التطبيق بين المشرفين والمستخدمين العاديين، مما يضمن أن كل مستخدم يمكنه الوصول إلى البيانات والإجراءات المناسبة.
+
+تنظيم حسب الفروع: يتم تخصيص المستخدمين إلى فروع محددة، ويمكن للمشرفين إدارة المستخدمين والملفات ضمن فرعهم.
+
+إدارة الملفات: يمكن للمستخدمين رفع الملفات، ويمكن للمشرفين مشاهدة وإدارة جميع الملفات ضمن فرعهم.
+
+التقنيات المستخدمة:
+
+Laravel مع Breeze
+
+React مع Inertia.js
+
+المشكلة: أواجه مشكلة في فصل داشبورد المشرف عن داشبورد المستخدم، حيث يظهر المحتوى الخاص بالمستخدم العادي أيضًا في صفحة المشرف
+---------------------------------------------------------------------
+
+This application is a file management system designed to securely manage files across branches with different roles for supervisors and regular users. Supervisors can manage files, users, and oversee branch operations, while regular users can upload and view files related to their department.
+
+The system uses Laravel with Breeze for backend management and React with Inertia.js for the frontend, providing an interactive and smooth user experience.
+
+Features:
+
+Role-based Access: The application distinguishes between supervisors and regular users, ensuring that each user has access to the appropriate data and actions.
+
+Branch-based Organization: Users are assigned to specific branches, and supervisors can manage users and files within their branch.
+
+File Management: Users can upload files, and supervisors can view and manage all files within their branch.
+
+Technologies Used:
+
+Laravel with Breeze
+
+React with Inertia.js
+
+Issue: I am facing an issue where the supervisor's dashboard is showing content from the regular user as well.
+
+
+
+
+
+
+


### PR DESCRIPTION
اواجه مشكلة تتعلق بفصل لوحة معلومات المُشرف عن لوحة معلومات المستخدم العادي. تتعلق المشكلة بظهور محتوى لوحة معلومات المستخدم على صفحة المُشرف، وهو أمرٌ لا يزال بحاجة إلى حلّ لضمان التحكم السليم في الوصول بناءً على الدور.                                             

I'm having an issue with separating the admin dashboard from the regular user dashboard. The issue is that the user dashboard content appears on the admin page, and this still needs to be resolved to ensure proper role-based access control.